### PR TITLE
Support bors' "Delegating reviews" command syntax

### DIFF
--- a/src/parser/__tests__/test_parser.js
+++ b/src/parser/__tests__/test_parser.js
@@ -113,6 +113,15 @@ const REJECT_REVIEW_TEST_CASE_LIST = [
     testCase('r -', null),
 ];
 
+// We should avoid "Delegating reviews" case in https://bors.tech/documentation/getting-started/
+const BORS_DELEGETE_COMMAND_TEST_CASE_LIST = [
+    testCase('@some-user: bors r+', null),
+    testCase('@bors[bot]: Permission denied', null),
+    testCase('@some-reviewer: bors delegate=some-user', null),
+    testCase('@bors[bot]: some-user now has permission to review this pull request.', null),
+    testCase('@bors[bot]: Added to queue', null),
+];
+
 const TEST_CASE_LIST = [
     ...REQUEST_REVIEW_TEST_CASE_LIST,
     ...[
@@ -135,6 +144,7 @@ const TEST_CASE_LIST = [
         ...withMultipleBotName(REJECT_REVIEW_TEST_CASE_LIST),
     ],
 
+    ...BORS_DELEGETE_COMMAND_TEST_CASE_LIST,
 ];
 
 for (const testCase of TEST_CASE_LIST) {

--- a/src/parser/parser.js
+++ b/src/parser/parser.js
@@ -36,6 +36,10 @@ function parseString(input) {
             return null;
         }
 
+        if (token.type === TokenType.Separator || token.type === TokenType.ListSeparator) {
+            return null;
+        }
+
         if (token.type === TokenType.ReviewDirective) {
             break;
         }

--- a/src/parser/scanner.js
+++ b/src/parser/scanner.js
@@ -100,7 +100,7 @@ const CHAR_LIST_SEPATOR = ',';
  *  @returns    {boolean}
  */
 function isSeparator(char) {
-    return (char === CHAR_LIST_SEPATOR) || (char === ';') || (char === '.');
+    return (char === CHAR_LIST_SEPATOR) || (char === ':') || (char === ';') || (char === '.');
 }
 
 /**


### PR DESCRIPTION
I'd like to support this syntax:

> https://bors.tech/documentation/getting-started/
>
> **Delegating reviews**
>
> In addition to adding reviewers who can approve any PR in the repo, you can “delegate” permission to approve a single PR to anyone else. It works like this:
>
> 

        @some-user: bors r+
        @bors[bot]: Permission denied
        @some-reviewer: bors delegate=some-user
        @bors[bot]: some-user now has permission to review this pull request.
        @some-user: bors r+
        @bors[bot]: Added to queue

