### PR TITLE
Reduce spreading internal error with neutral 78

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,12 +82,10 @@ const {
             throw new RangeError('unreachable!');
     }
 
-    // TODO: assert
-    assert.strictEqual(
-        typeof commentBody,
-        'string',
-        'commentBody should be string'
-    );
+    if (typeof commentBody !== 'string') {
+        console.warn('commentBody should be string', typeof commentBody);
+        process.exit(78);
+    }
 
     const command = parseString(commentBody);
     if (command === null) {


### PR DESCRIPTION
Reduce this error:

<img width="303" alt="スクリーンショット 2019-03-13 12 01 50" src="https://user-images.githubusercontent.com/2971112/54250626-e700c680-4587-11e9-9392-7c231588f079.png">
<img width="462" alt="スクリーンショット 2019-03-13 12 01 41" src="https://user-images.githubusercontent.com/2971112/54250632-e9fbb700-4587-11e9-801c-677614f51839.png">

- What does exit code 78 mean?
See: https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#exit-codes-and-statuses