### PR TITLE
Fix assignee of AcceptPullRequest with r=reviewers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,7 @@ const {
             task = assignReviewer;
             break;
         case CommandType.AcceptPullRequest:
-            nextAssignee = [issueCreator];
+            nextAssignee = command.target || [issueCreator];
             task = acceptPullRequest;
             break;
         case CommandType.RejectPullRequest:


### PR DESCRIPTION
Since https://github.com/cats-oss/github-action-auto-assign/pull/13, an instance of Command with `CommandType.AcceptPullRequest` command type has also `user` target property.

https://github.com/cats-oss/github-action-auto-assign/blob/b57eb97ec616fc9486999aac117dff4755bb5878/src/parser/parser.js#L107

But in case of AcceptPullRequest, a value of `nextAssignee` has fixed value: `[issueCreator]`; it means `r=username` syntax doesn't work.

https://github.com/cats-oss/github-action-auto-assign/blob/35b5056872dc80946290ad5c8c3991f2d58c5c6d/src/index.js#L103-L106

So, I tried to fix this problem with `||` operator because `command.target` is [nullable](https://github.com/cats-oss/github-action-auto-assign/blob/b57eb97ec616fc9486999aac117dff4755bb5878/src/parser/parser.js#L83).