### PR TITLE
Migrate action definition to new yaml syntax

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,5 @@
+name: 'Auto assign a reviewer by comment command'
+description: 'Auto assign by your comment like highfive or popuko'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'


### PR DESCRIPTION
Fix https://github.com/cats-oss/github-action-auto-assign/issues/53