### PR TITLE
bors-ng should check the CI result by CircleCI.

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,6 @@
+# We should sort this field with a status label,
 status = [
-    "ci/circleci"
+    "build_and_test",
+    # bors does not check this status. So we should not specify this.
+    # "license/cla",
 ]


### PR DESCRIPTION
If we don't use a custom workflow, we should specify
[`"ci/circleci%"`](https://github.com/bors-ng/bors-ng/blob/680408ef8c3061078a3d6b3b264a374ba8682ade/lib/worker/batcher/get_bors_toml.ex).

But we use a custom workflow.
Thus we need to specify the matched status label to `status` field in
`bors.toml`.