### PR TITLE
Return if `commentBody` is not string

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,8 +83,8 @@ const {
     }
 
     if (typeof commentBody !== 'string') {
-        console.warn('commentBody should be string', typeof commentBody);
-        process.exit(78);
+        console.warn(`commentBody should be string, but typeof \`${typeof commentBody}\`, value is \`${commentBody}\``);
+        return;
     }
 
     const command = parseString(commentBody);


### PR DESCRIPTION
I found the case that eventData.review.body is `null` with GITHUB_EVENT_NAME=pull_request_review.
This fix is workaround for it.