### PR TITLE
Send review requests when assigning reviewers

### DIFF
--- a/src/pulls.js
+++ b/src/pulls.js
@@ -1,0 +1,21 @@
+/**
+ * @param {import('@octokit/rest').Octokit} aOctoKit
+ * @param {string} owner
+ * @param {string} repo
+ * @param {number} issueOrPullNumber
+ * @return {Promise<boolean>}
+ */
+export async function isPullRequest(aOctoKit, owner, repo, issueOrPullNumber) {
+    try {
+        await aOctoKit.pulls.get({
+            owner,
+            repo,
+            // eslint-disable-next-line camelcase
+            pull_number: issueOrPullNumber,
+        });
+
+        return true;
+    } catch (_e) {
+        return false;
+    }
+}


### PR DESCRIPTION
Closes #207 

This PR adds a feature to send review requests when assigning reviewers by the `r?` command.

- [x] Confirmed that the action works as expected for pull requests.
  - https://github.com/nodaguti/github-action-auto-assign/pull/4
  - Note: `@exmaple-redirect` is my test account
  - <img width="390" alt="image" src="https://user-images.githubusercontent.com/27622/129466408-d7391276-8a60-4f0b-8ca5-979ac2da0631.png">
- [x] Confirmed that the action works without errors for issues.
  - https://github.com/nodaguti/github-action-auto-assign/issues/2
  - <img width="399" alt="image" src="https://user-images.githubusercontent.com/27622/129466403-f8aa00ca-c789-4cc8-ad82-782357e8a97b.png">

As per https://github.com/cats-oss/github-action-auto-assign/issues/207#issuecomment-861564722, configurations for this new feature are not implemented. In my opinion, it'd be good to keep the feature simple at this moment and start considering them after we find their real use cases.