### PR TITLE
Use strict assertion mode

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import * as assert from 'assert/strict';
 import * as fs from 'fs/promises';
 
 import { Octokit } from '@octokit/rest';


### PR DESCRIPTION
Do not use loose assertion mode.

## Checklist

- [x] No loose assertion mode is used

`git grep` result:

```shell
(*'-') < git grep assert
src/index.mjs:1:import * as assert from 'assert/strict';
src/index.mjs:18: *  @returns {asserts value is string}
src/index.mjs:21:    assert.strictEqual(
src/operations.js:33:        // TODO: assert return value
src/operations.js:71:        // TODO: assert return value
src/parser/parser.js:1:import * as assert from 'assert/strict';
src/parser/parser.js:50:        assert.ok(!!token, 'token should not null');
src/parser/parser.js:67:        assert.ok(!!token, 'token should not null');
```